### PR TITLE
Tests fail due to wrong import path

### DIFF
--- a/tests/Extractor/AttributeExtractorTest.php
+++ b/tests/Extractor/AttributeExtractorTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use ApiValidator\Extractor\AttributeExtractor;
-use ApiValidator\Parser\NodeParser;
+use Apilyser\Extractor\AttributeExtractor;
+use Apilyser\Parser\NodeParser;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeFinder;
 use PHPUnit\Framework\TestCase;

--- a/tests/Rule/ParameterExistenceRuleTest.php
+++ b/tests/Rule/ParameterExistenceRuleTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use ApiValidator\Comparison\ValidationError;
-use ApiValidator\Comparison\ValidationSuccess;
-use ApiValidator\Definition\EndpointDefinition;
-use ApiValidator\Definition\ParameterDefinition;
-use ApiValidator\Definition\RequestType;
-use ApiValidator\Rule\ParameterExistenceRule;
+use Apilyser\Comparison\ValidationError;
+use Apilyser\Comparison\ValidationSuccess;
+use Apilyser\Definition\EndpointDefinition;
+use Apilyser\Definition\ParameterDefinition;
+use Apilyser\Definition\RequestType;
+use Apilyser\Rule\ParameterExistenceRule;
 use PHPUnit\Framework\TestCase;
 
 class ParameterExistenceRuleTest extends TestCase

--- a/tests/Rule/ParameterTypeRuleTest.php
+++ b/tests/Rule/ParameterTypeRuleTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use ApiValidator\Comparison\ValidationError;
-use ApiValidator\Comparison\ValidationSuccess;
-use ApiValidator\Definition\EndpointDefinition;
-use ApiValidator\Definition\ParameterDefinition;
-use ApiValidator\Definition\RequestType;
-use ApiValidator\Rule\ParameterTypeRule;
+use Apilyser\Comparison\ValidationError;
+use Apilyser\Comparison\ValidationSuccess;
+use Apilyser\Definition\EndpointDefinition;
+use Apilyser\Definition\ParameterDefinition;
+use Apilyser\Definition\RequestType;
+use Apilyser\Rule\ParameterTypeRule;
 use PHPUnit\Framework\TestCase;
 
 class ParameterTypeRuleTest extends TestCase

--- a/tests/Rule/ResponseExistenceRuleTest.php
+++ b/tests/Rule/ResponseExistenceRuleTest.php
@@ -1,10 +1,9 @@
 <?php
 
-use ApiValidator\Comparison\ValidationError;
-use ApiValidator\Definition\EndpointDefinition;
-use ApiValidator\Definition\ResponseBodyDefinition;
-use ApiValidator\Definition\ResponseDefinition;
-use ApiValidator\Rule\ResponseExistenceRule;
+use Apilyser\Comparison\ValidationError;
+use Apilyser\Definition\EndpointDefinition;
+use Apilyser\Definition\ResponseDefinition;
+use Apilyser\Rule\ResponseExistenceRule;
 use PHPUnit\Framework\TestCase;
 
 class ResponseExistenceRuleTest extends TestCase

--- a/tests/Rule/ResponsePropertyTypeRuleTest.php
+++ b/tests/Rule/ResponsePropertyTypeRuleTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use ApiValidator\Comparison\ValidationError;
-use ApiValidator\Comparison\ValidationSuccess;
-use ApiValidator\Definition\EndpointDefinition;
-use ApiValidator\Definition\ResponseBodyDefinition;
-use ApiValidator\Definition\ResponseDefinition;
-use ApiValidator\Rule\ResponsePropertyTypeRule;
+use Apilyser\Comparison\ValidationError;
+use Apilyser\Comparison\ValidationSuccess;
+use Apilyser\Definition\EndpointDefinition;
+use Apilyser\Definition\ResponseBodyDefinition;
+use Apilyser\Definition\ResponseDefinition;
+use Apilyser\Rule\ResponsePropertyTypeRule;
 use PHPUnit\Framework\TestCase;
 
 class ResponsePropertyTypeRuleTest extends TestCase

--- a/tests/Rule/ResponseSchemePropertiesRuleTest.php
+++ b/tests/Rule/ResponseSchemePropertiesRuleTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use ApiValidator\Comparison\ValidationError;
-use ApiValidator\Comparison\ValidationSuccess;
-use ApiValidator\Definition\EndpointDefinition;
-use ApiValidator\Definition\ResponseBodyDefinition;
-use ApiValidator\Definition\ResponseDefinition;
-use ApiValidator\Rule\ResponseSchemePropertiesRule;
+use Apilyser\Comparison\ValidationError;
+use Apilyser\Comparison\ValidationSuccess;
+use Apilyser\Definition\EndpointDefinition;
+use Apilyser\Definition\ResponseBodyDefinition;
+use Apilyser\Definition\ResponseDefinition;
+use Apilyser\Rule\ResponseSchemePropertiesRule;
 use PHPUnit\Framework\TestCase;
 
 class ResponseSchemePropertiesRuleTest extends TestCase


### PR DESCRIPTION
The tests currently use the old namespace for all classes. This PR is changes the use paths to match the new namespaces, making the tests succeed again